### PR TITLE
Add DHCP discovery

### DIFF
--- a/custom_components/homey/manifest.json
+++ b/custom_components/homey/manifest.json
@@ -4,6 +4,14 @@
   "codeowners": ["@ifmike"],
   "config_flow": true,
   "dependencies": [],
+  "dhcp": [
+    {
+      "registered_devices": true
+    },
+    {
+      "macaddress": "9013DA*"
+    }
+  ],
   "documentation": "https://github.com/ifMike/homeyHASS",
   "integration_type": "hub",
   "iot_class": "local_polling",


### PR DESCRIPTION
DHCP discovery of the Homey device.

I don't own a Homey, but a friend of mine does and I found out the integration doesn't do discovery when installing HA at his place. Thus hereby an initial implementation. You have to fill in the blanks yourself. I'm happy to help